### PR TITLE
add highlighting of character references (entities)

### DIFF
--- a/lib/brush-xml.js
+++ b/lib/brush-xml.js
@@ -43,6 +43,7 @@
 		this.regexList = [
 			{ regex: XRegExp('(\\&lt;|<)\\!\\[[\\w\\s]*?\\[(.|\\s)*?\\]\\](\\&gt;|>)', 'gm'),			css: 'color2' },	// <![ ... [ ... ]]>
 			{ regex: SyntaxHighlighter.regexLib.xmlComments,												css: 'comments' },	// <!-- ... -->
+			{ regex: XRegExp('(&amp;)\\#?\\w+;', 'gm'),													css: 'value' },		// character references
 			{ regex: XRegExp('(&lt;|<)[\\s\\/\\?!]*(\\w+)(?<attributes>.*?)[\\s\\/\\?]*(&gt;|>)', 'sg'), func: process }
 		];
 	};


### PR DESCRIPTION
The additional regex here adds highlighting of character references (aka entities) in XML and HTML files. I think that helps the readability of code (and certainly most editors do it).
